### PR TITLE
Ore box and manager

### DIFF
--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -10,11 +10,18 @@
 	deflect_chance = 10
 	step_energy_drain = 15 //slightly higher energy drain since you movin those wheels FAST
 	armor = list("melee" = 20, "bullet" = 10, "laser" = 20, "energy" = 10, "bomb" = 60, "bio" = 0, "rad" = 70, "fire" = 100, "acid" = 100) //low armor to compensate for fire protection and speed
-	max_equip = 6
+	max_equip = 7
 	wreckage = /obj/structure/mecha_wreckage/clarke
 	enter_delay = 40
 	cargo_capacity = 10
 	canstrafe = FALSE
+	var/obj/structure/ore_box/box
+
+/obj/mecha/working/clarke/Initialize()
+	. = ..()
+	box = new /obj/structure/ore_box(src)
+	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/orebox_manager(src)
+	ME.attach(src)
 
 /obj/mecha/working/clarke/moved_inside(mob/living/carbon/human/H)
 	. = ..()
@@ -35,3 +42,32 @@
 		var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_DIAGNOSTIC_ADVANCED]
 		var/mob/living/brain/B = M.brainmob
 		hud.add_hud_to(B)
+
+////Ore Box Controls////
+
+/obj/item/mecha_parts/mecha_equipment/orebox_manager //Special equipment for Clarke
+	name = "ore storage module"
+	desc = "An automated ore box management device."
+	icon_state = "mecha_clamp" //None of this should matter, this shouldn't ever exist outside a mech anyway.
+	selectable = FALSE
+	detachable = FALSE
+	salvageable = FALSE
+	var/obj/mecha/working/clarke/hostmech //New var to avoid istype checking every time the topic button is pressed. This will only work inside Clarke mechs
+
+/obj/item/mecha_parts/mecha_equipment/orebox_manager/attach(obj/mecha/M)
+	if(istype(M, /obj/mecha/working/clarke))
+		hostmech = M
+	. = ..()
+
+/obj/item/mecha_parts/mecha_equipment/orebox_manager/detach()
+	hostmech = null //just in case
+	. = ..()
+
+/obj/item/mecha_parts/mecha_equipment/orebox_manager/Topic(href,href_list)
+	..()
+	if(!hostmech || !hostmech.box)
+		return
+	hostmech.box.dump_box_contents()
+
+/obj/item/mecha_parts/mecha_equipment/orebox_manager/get_equip_info()
+	return "[..()] [hostmech?.box?"<a href='?src=[REF(src)];mode=0'>Unload Cargo</a>":"Error"]"

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -9,8 +9,8 @@
 		collect_ore()
 
 /obj/mecha/working/proc/collect_ore()
-	if(locate(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp) in equipment)
-		var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in cargo
+	if((locate(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp) in equipment) || (locate(/obj/item/mecha_parts/mecha_equipment/orebox_manager) in equipment))
+		var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in contents
 		if(ore_box)
 			for(var/obj/item/stack/ore/ore in range(1, src))
 				if(ore.Adjacent(src) && ((get_dir(src, ore) & dir) || ore.loc == loc)) //we can reach it and it's in front of us? grab it!


### PR DESCRIPTION
- Places an ore box into the Clarke upon creation.
- Adds a new equipment for managing the ore box (since the box can't be dropped). Equipment is also not detachable, and is attached to the Clarke upon creation.
- Increases the max_equip of the Clarke to 7 (functionally leaving the total number of usable equipment spots at 6).
- Changes the `collect_ore()` proc to work with the new ore manager equipment.
